### PR TITLE
refactor: use decorators to register subclasses of `Message`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
-exclude = ".venv"
+exclude = .venv
 max-line-length = 120
+extend-ignore = E203,E701

--- a/cz4013_group_project/message.py
+++ b/cz4013_group_project/message.py
@@ -1,51 +1,63 @@
 import socket
+from abc import ABC, abstractmethod
 
 
-class Message:
-    def __init__(self, message_type_identifier: int):
-        self.message_type_identifier: int = message_type_identifier
+class Message(ABC):
+    class_id_to_class_ref = {}
+    class_ref_to_class_id = {}
+
+    @classmethod
+    def register_subclass(cls, class_id):
+        def decorator(subclass):
+            cls.class_id_to_class_ref[class_id] = subclass
+            cls.class_ref_to_class_id[subclass] = class_id
+            return subclass
+
+        return decorator
 
     def marshall(self) -> bytes:
-        message_type_identifier = self.message_type_identifier.to_bytes(4, "big")
-        return message_type_identifier
+        if self.__class__ not in self.class_ref_to_class_id:
+            raise RuntimeError(f"{self.__class__} has not been registered as a subclass")
+        class_id: bytes = self.class_ref_to_class_id[self.__class__].to_bytes(4, "big")
+        return class_id + self._marshall_without_type_info()
+
+    @classmethod
+    def unmarshall(cls, content: bytes) -> "Message":
+        class_id: int = int.from_bytes(content[0:4], "big")
+        if class_id not in cls.class_id_to_class_ref:
+            raise RuntimeError(f"Unsupported class identifier: {class_id}")
+        return cls.class_id_to_class_ref[class_id]._unmarshall_without_type_info(content[4:])
+
+    @abstractmethod
+    def _marshall_without_type_info(self) -> bytes:
+        pass
 
     @staticmethod
-    def unmarshall(content: bytes) -> "Message":
-        class_mapping = {
-            1: ReadFileRequest,
-            2: WriteFileRequest,
-            3: SubscribeToUpdatesRequest,
-            4: ReadFileResponse,
-            5: WriteFileResponse,
-        }
-        class_identifier = int.from_bytes(content[0:4], "big")
-
-        if class_identifier in class_mapping:
-            return class_mapping[class_identifier].unmarshall(content[4:])
-        else:
-            raise ValueError(f"Unsupported class identifier: {class_identifier}")
+    @abstractmethod
+    def _unmarshall_without_type_info(content: bytes) -> "Message":
+        pass
 
 
 # Client
+@Message.register_subclass(class_id=1)
 class ReadFileRequest(Message):
     def __init__(self, request_id: int, offset: int, read_bytes: int, filename: str):
-        super().__init__(1)
         self.request_id: int = request_id
         self.offset: int = offset
         self.read_bytes: int = read_bytes
         self.file_name: str = filename
 
-    def marshall(self) -> bytes:
+    def _marshall_without_type_info(self) -> bytes:
         file_name: bytearray = bytearray(self.file_name, encoding="utf-8")
         file_name_length: bytes = len(file_name).to_bytes(4, "big")
         request_id: bytes = self.request_id.to_bytes(4, "big")
         offset: bytes = self.offset.to_bytes(4, "big")
         read_bytes: bytes = self.read_bytes.to_bytes(4, "big")
-        # return request_id + offset + read_bytes + file_name_length + file_name
-        return super().marshall() + request_id + offset + read_bytes + file_name_length + file_name
+
+        return request_id + offset + read_bytes + file_name_length + file_name
 
     @staticmethod
-    def unmarshall(content: bytes) -> "ReadFileRequest":
+    def _unmarshall_without_type_info(content: bytes) -> "ReadFileRequest":
         request_id: int = int.from_bytes(content[0:4], "big")
         offset: int = int.from_bytes(content[4:8], "big")
         read_bytes: int = int.from_bytes(content[8:12], "big")
@@ -63,17 +75,15 @@ class ReadFileRequest(Message):
         )
 
 
+@Message.register_subclass(class_id=2)
 class WriteFileRequest(Message):
-    message_type_identifier: int = 2
-
     def __init__(self, request_id: int, offset: int, file_name: str, content: bytes):
-        super().__init__(2)
         self.request_id: int = request_id
         self.offset: int = offset
         self.file_name: str = file_name
         self.content: bytes = content
 
-    def marshall(self) -> bytes:
+    def _marshall_without_type_info(self) -> bytes:
         byte_id: bytes = self.request_id.to_bytes(4, "big")
         byte_offset: bytes = self.offset.to_bytes(4, "big")
         byte_filename: bytearray = bytearray(self.file_name, encoding="utf-8")
@@ -84,16 +94,16 @@ class WriteFileRequest(Message):
         marshalled_content = (
             byte_id + byte_offset + byte_filename_length + byte_content_length + byte_filename + byte_content
         )
-        return super().marshall() + marshalled_content
+        return marshalled_content
 
     @staticmethod
-    def unmarshall(content: bytes) -> "WriteFileRequest":
+    def _unmarshall_without_type_info(content: bytes) -> "WriteFileRequest":
         request_id = int.from_bytes(content[0:4], "big")
         offset = int.from_bytes(content[4:8], "big")
         filename_length = int.from_bytes(content[8:12], "big")
         content_length = int.from_bytes(content[12:16], "big")
-        filename = content[16: 16 + filename_length].decode("utf-8")
-        file_content = content[16 + filename_length: 16 + filename_length + content_length]
+        filename = content[16 : 16 + filename_length].decode("utf-8")
+        file_content = content[16 + filename_length : 16 + filename_length + content_length]
 
         return WriteFileRequest(request_id, offset, filename, file_content)
 
@@ -107,38 +117,31 @@ class WriteFileRequest(Message):
         )
 
 
+@Message.register_subclass(class_id=3)
 class SubscribeToUpdatesRequest(Message):
     def __init__(self, client_ip_address, client_port_number, monitoring_interval, file_name_length, file_name):
-        super().__init__(3)
         self.client_ip_address: str = client_ip_address
         self.client_port_number: int = client_port_number
         self.monitoring_interval: int = monitoring_interval
         self.file_name_length: int = file_name_length
         self.file_name: str = file_name
 
-    def marshall(self) -> bytes:
+    def _marshall_without_type_info(self) -> bytes:
         client_ip_address: bytes = socket.inet_aton(self.client_ip_address)
         client_port_number: bytes = self.client_port_number.to_bytes(4, "big")
         monitoring_interval: bytes = self.monitoring_interval.to_bytes(4, "big")
         file_name_length: bytes = self.file_name_length.to_bytes(4, "big")
         file_name: bytearray = bytearray(self.file_name, encoding="utf-8")
 
-        return (
-            super().marshall()
-            + client_ip_address
-            + client_port_number
-            + monitoring_interval
-            + file_name_length
-            + file_name
-        )
+        return client_ip_address + client_port_number + monitoring_interval + file_name_length + file_name
 
     @staticmethod
-    def unmarshall(content: bytes) -> "SubscribeToUpdatesRequest":
+    def _unmarshall_without_type_info(content: bytes) -> "SubscribeToUpdatesRequest":
         client_ip_address: str = socket.inet_ntoa(content[0:4])
         client_port_number: int = int.from_bytes(content[4:8], "big")
         monitoring_interval: int = int.from_bytes(content[8:12], "big")
         filename_length: int = int.from_bytes(content[12:16], "big")
-        file_name: str = content[16: 16 + filename_length].decode("utf-8")
+        file_name: str = content[16 : 16 + filename_length].decode("utf-8")
 
         return SubscribeToUpdatesRequest(
             client_ip_address, client_port_number, monitoring_interval, filename_length, file_name
@@ -156,66 +159,67 @@ class SubscribeToUpdatesRequest(Message):
 
 
 # Server
+@Message.register_subclass(class_id=4)
 class ReadFileResponse(Message):
     def __init__(self, reply_id, content):
-        super().__init__(4)
         self.reply_id: int = reply_id
         self.content: str = content
 
-    def marshall(self) -> bytes:
+    def _marshall_without_type_info(self) -> bytes:
         byte_id: bytes = self.reply_id.to_bytes(4, "big")
         byte_content: bytearray = bytearray(self.content, encoding="utf-8")
         marshalled_content: bytes = byte_id + byte_content
-
-        return super().marshall() + marshalled_content
+        return marshalled_content
 
     @staticmethod
-    def unmarshall(content: bytes) -> "ReadFileResponse":
+    def _unmarshall_without_type_info(content: bytes) -> "ReadFileResponse":
         reply_id = int.from_bytes(content[0:4], "big")
         content = content[4:].decode("utf-8")
         return ReadFileResponse(reply_id, content)
 
 
+@Message.register_subclass(class_id=5)
 class WriteFileResponse(Message):
     def __init__(self, reply_id, is_successful):
-        super().__init__(5)
         self.reply_id: int = reply_id
         self.is_successful: bool = is_successful
 
-    def marshall(self) -> bytes:
+    def _marshall_without_type_info(self) -> bytes:
         byte_id: bytes = self.reply_id.to_bytes(4, "big")
         byte_success: bytes = int(self.is_successful).to_bytes(1, "big")
         marshalled_content = byte_id + byte_success
-        return super().marshall() + marshalled_content
+        return marshalled_content
 
     @staticmethod
-    def unmarshall(content: bytes) -> "WriteFileResponse":
+    def _unmarshall_without_type_info(content: bytes) -> "WriteFileResponse":
         reply_id = int.from_bytes(content[0:4], "big")
         is_successful = content[4:].decode("utf-8")
         return WriteFileResponse(reply_id, is_successful)
 
 
 # TODO: complete marshalling and unmarshalling and create test
-class SubscribeToUpdatesResponse:
+class SubscribeToUpdatesResponse(Message):
     def __init__(self):
         self.reply_id: int
         self.is_successful: bool
 
-    def marshall(self) -> bytearray:
+    def _marshall_without_type_info(self) -> bytes:
         pass
 
-    def unmarshall(self, content: bytearray) -> "SubscribeToUpdatesResponse":
+    @staticmethod
+    def _unmarshall_without_type_info(content: bytes) -> "SubscribeToUpdatesResponse":
         pass
 
 
 # TODO: complete marshalling and unmarshalling and create test
-class UpdateNotification:
+class UpdateNotification(Message):
     def __init__(self):
         self.file_name: str
-        self.content: bytearray
+        self.content: bytes
 
-    def marshall(self) -> bytearray:
+    def _marshall_without_type_info(self) -> bytes:
         pass
 
-    def unmarshall(self, content: bytearray) -> "UpdateNotification":
+    @staticmethod
+    def _unmarshall_without_type_info(content: bytes) -> "UpdateNotification":
         pass

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -18,8 +18,8 @@ class TestReadFileRequest:
         read_file_request: ReadFileRequest = ReadFileRequest(
             request_id=123, offset=456, read_bytes=15, filename="random_file_name"
         )
-        marshalled_data: bytes = read_file_request.marshall()
-        unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
+        marshalled_data: bytes = read_file_request._marshall_without_type_info()
+        unmarshalled_obj: Message = ReadFileRequest._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == read_file_request
 
 
@@ -29,8 +29,8 @@ class TestWriteFileRequest:
         write_file_request: WriteFileRequest = WriteFileRequest(
             request_id=123, offset=456, file_name="random_file", content=b"random_file_content"
         )
-        marshalled_data: bytes = write_file_request.marshall()
-        unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
+        marshalled_data: bytes = write_file_request._marshall_without_type_info()
+        unmarshalled_obj: Message = WriteFileRequest._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == write_file_request
 
 
@@ -44,6 +44,6 @@ class TestSubscribeToUpdatesRequest:
             file_name="random_file_name",
             file_name_length=len("random_file_name"),
         )
-        marshalled_data: bytes = subscribe_request.marshall()
-        unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
+        marshalled_data: bytes = subscribe_request._marshall_without_type_info()
+        unmarshalled_obj: Message = SubscribeToUpdatesRequest._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == subscribe_request

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -3,13 +3,22 @@ from cz4013_group_project.message import Message, ReadFileRequest, WriteFileRequ
 
 class TestMessage:
     @staticmethod
-    def test_unmarshall():
+    def test_marshall_unmarshall_read_file_request():
         read_file_request: ReadFileRequest = ReadFileRequest(
             request_id=155, offset=777, read_bytes=15, filename="random_file_name"
         )
         marshalled_data: bytes = read_file_request.marshall()
         unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
         assert unmarshalled_obj == read_file_request
+
+    @staticmethod
+    def test_marshall_unmarshall_write_file_request():
+        write_file_request: WriteFileRequest = WriteFileRequest(
+            request_id=123, offset=456, file_name="random_file", content=b"random_file_content"
+        )
+        marshalled_data: bytes = write_file_request.marshall()
+        unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
+        assert unmarshalled_obj == write_file_request
 
 
 class TestReadFileRequest:
@@ -19,7 +28,7 @@ class TestReadFileRequest:
             request_id=123, offset=456, read_bytes=15, filename="random_file_name"
         )
         marshalled_data: bytes = read_file_request._marshall_without_type_info()
-        unmarshalled_obj: Message = ReadFileRequest._unmarshall_without_type_info(marshalled_data)
+        unmarshalled_obj: ReadFileRequest = ReadFileRequest._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == read_file_request
 
 
@@ -30,7 +39,7 @@ class TestWriteFileRequest:
             request_id=123, offset=456, file_name="random_file", content=b"random_file_content"
         )
         marshalled_data: bytes = write_file_request._marshall_without_type_info()
-        unmarshalled_obj: Message = WriteFileRequest._unmarshall_without_type_info(marshalled_data)
+        unmarshalled_obj: WriteFileRequest = WriteFileRequest._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == write_file_request
 
 
@@ -45,5 +54,21 @@ class TestSubscribeToUpdatesRequest:
             file_name_length=len("random_file_name"),
         )
         marshalled_data: bytes = subscribe_request._marshall_without_type_info()
-        unmarshalled_obj: Message = SubscribeToUpdatesRequest._unmarshall_without_type_info(marshalled_data)
+        unmarshalled_obj: SubscribeToUpdatesRequest = SubscribeToUpdatesRequest._unmarshall_without_type_info(
+            marshalled_data
+        )
         assert unmarshalled_obj == subscribe_request
+
+
+class TestReadFileResponse:
+    @staticmethod
+    def test_marshall_unmarshall():
+        # TODO write unit test
+        assert True
+
+
+class TestWriteFileResponse:
+    @staticmethod
+    def test_marshall_unmarshall():
+        # TODO write unit test
+        assert True


### PR DESCRIPTION
This PR resolves the following issues with the marshalling/unmarshalling methods of the `Message` class in the previous version:
- `marshall()` and `unmarshall()` in the subclasses were asymmetrical, since `marshall()` encoded the type information into the sequence of bytes but `unmarshall()` decodes the sequence of bytes without expecting any type information
- possible violation of Open/Closed Principle since the `Message` base class may need to be changed to accommodate new subclasses in the future

The following changes were made:
- direct references to subclasses of `Message` were removed from the `Message` class itself
- added a `register_subclass` decorator to allow subclasses to automatically register themselves with the base `Message` class