### PR TITLE
structure for client cache

### DIFF
--- a/remote_file_system/client_cache.py
+++ b/remote_file_system/client_cache.py
@@ -1,0 +1,16 @@
+class Cache:
+    def __init__(self, cache_location: str, freshness_interval_in_seconds: int):
+        self.cache_location: str = cache_location
+        self.freshness_interval_in_seconds: int = freshness_interval_in_seconds
+
+    def is_in_cache(self, file_name: str) -> bool:
+        pass
+
+    def put_in_cache(self, file_name: str, content: str) -> None:
+        pass
+
+    def get_from_cache(self, file_name: str) -> bytes:
+        pass
+
+    def get_file_metadata(self, file_path: str):
+        pass

--- a/remote_file_system/client_interface.py
+++ b/remote_file_system/client_interface.py
@@ -26,7 +26,7 @@ class Client:
         self.server_port_number: int = server_port_number
 
     def read_file(self, file_name: str, offset: int, number_of_bytes: int) -> bytes:
-        # TODO: check cache if file_name exists in cache + within freshness, if yes, return immmediately
+        # TODO: check cache if file_name exists in cache + within freshness, if yes, return immediately
 
         outgoing_message: Message = ReadFileRequest(request_id=uuid4(), filename=file_name)
         incoming_message: ReadFileResponse = send_message(

--- a/remote_file_system/server_dispatcher.py
+++ b/remote_file_system/server_dispatcher.py
@@ -15,6 +15,8 @@ from remote_file_system.message import (
     UpdateNotification,
     SubscribeToUpdatesRequest,
     SubscribeToUpdatesResponse,
+    ModifiedTimestampRequest,
+    ModifiedTimestampResponse,
 )
 from remote_file_system.server_interface import Server
 
@@ -72,6 +74,10 @@ def dispatch_message(server: Server, message: Message) -> Message:
             file_name=message.file_name,
         )
         return SubscribeToUpdatesResponse(is_successful=isSuccessful, reply_id=uuid4())
+    elif isinstance(message, ModifiedTimestampRequest):
+        data: int = server.get_modified_timestamp(file_path=message.file_path)
+        # TODO: implement is_successful later on
+        return ModifiedTimestampResponse(reply_id=uuid4(), is_successful=True, modification_timestamp=data)
     logger.error("Server received an unrecognised message.")
 
 

--- a/remote_file_system/server_interface.py
+++ b/remote_file_system/server_interface.py
@@ -33,6 +33,12 @@ class Server:
 
         return True, self.subscribed_clients[file_name]
 
+    def get_modified_timestamp(self, file_path: str) -> int:
+        if not os.path.exists(file_path):
+            raise RuntimeError(f"File path {file_path} does not exist.")
+        timestamp_of_modifications_to_file_in_seconds: int = int(os.path.getmtime(file_path))
+        return timestamp_of_modifications_to_file_in_seconds
+
     def subscribe_to_updates(
         self,
         client_ip_address: IPv4Address,

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,6 +1,6 @@
 from ipaddress import IPv4Address
 from uuid import uuid4
-
+import time
 from remote_file_system.message import (
     Message,
     ReadFileRequest,
@@ -10,6 +10,8 @@ from remote_file_system.message import (
     WriteFileResponse,
     SubscribeToUpdatesResponse,
     UpdateNotification,
+    ModifiedTimestampRequest,
+    ModifiedTimestampResponse,
 )
 
 
@@ -151,3 +153,45 @@ class TestUpdateNotification:
         marshalled_data: bytes = update_notification._marshall_without_type_info()
         unmarshalled_obj: UpdateNotification = UpdateNotification._unmarshall_without_type_info(marshalled_data)
         assert unmarshalled_obj == update_notification
+
+
+class TestModifiedTimestampRequest:
+    @staticmethod
+    def test_marshall_unmarshall():
+        modified_timestamp_request = ModifiedTimestampRequest(file_path="/test/path", request_id=uuid4())
+        marshalled_data: bytes = modified_timestamp_request.marshall()
+        unmarshalled_data: Message = Message.unmarshall(marshalled_data)
+        assert modified_timestamp_request == unmarshalled_data
+
+    @staticmethod
+    def test_marshall_unmarshall_without_type_info():
+        modified_timestamp_request: ModifiedTimestampRequest = ModifiedTimestampRequest(
+            file_path="/test/path", request_id=uuid4()
+        )
+        marshalled_data: bytes = modified_timestamp_request._marshall_without_type_info()
+        unmarshalled_obj: ModifiedTimestampRequest = ModifiedTimestampRequest._unmarshall_without_type_info(
+            marshalled_data
+        )
+        assert unmarshalled_obj == modified_timestamp_request
+
+
+class TestModifiedTimestampResponse:
+    @staticmethod
+    def test_marshall_unmarshall():
+        modified_timestamp_response: ModifiedTimestampResponse = ModifiedTimestampResponse(
+            reply_id=uuid4(), modification_timestamp=int(time.time())
+        )
+        marshalled_data: bytes = modified_timestamp_response.marshall()
+        unmarshalled_obj: Message = Message.unmarshall(marshalled_data)
+        assert unmarshalled_obj == modified_timestamp_response
+
+    @staticmethod
+    def test_marshall_unmarshall_without_type_info():
+        modified_timestamp_response: ModifiedTimestampResponse = ModifiedTimestampResponse(
+            reply_id=uuid4(), modification_timestamp=int(time.time())
+        )
+        marshalled_data: bytes = modified_timestamp_response._marshall_without_type_info()
+        unmarshalled_obj: ModifiedTimestampResponse = ModifiedTimestampResponse._unmarshall_without_type_info(
+            marshalled_data
+        )
+        assert unmarshalled_obj == modified_timestamp_response


### PR DESCRIPTION
This PR adds the `Cache` class and its method signatures for future implementation in a separate PR. It also introduces two subclasses of `Message`: `ModificationTimestampRequest` and `ModificationTimestampResponse`.

Work was completed as part of a pair programming session with @Eugene7997 and @jeremyu25.